### PR TITLE
Replace deprecated pysnmp-lextudio dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,7 +21,7 @@ passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 
 # SNMP
-pysnmp-lextudio==6.3.0
+pysnmp==6.2.6
 pyasn1==0.5.1
 
 # Scheduling


### PR DESCRIPTION
## Summary

Replaces the deprecated `pysnmp-lextudio` dependency with the official `pysnmp` package.

Speedarr currently emits this warning on startup:

```text
/app/app/services/snmp_monitor.py:8: RuntimeWarning: The 'pysnmp-lextudio' package is deprecated and will be removed in future releases. Please use 'pysnmp' instead.
  from pysnmp.hlapi.asyncio import (
  ```
This PR updates the dependency from:

```text
pysnmp-lextudio==6.3.0
  ```
to:

```text
pysnmp==6.2.6
  ```
No SNMP code changes were required. The existing import path in backend/app/services/snmp_monitor.py remains compatible with pysnmp==6.2.6.

## Why pysnmp==6.2.6

The deprecated package guidance recommends migrating back to the official pysnmp package while staying in the >=6.2.0,<7.0.0 range.

**pysnmp 7.x includes breaking API changes, so this PR uses 6.2.6** to preserve current Speedarr behavior and avoid a larger SNMP refactor.